### PR TITLE
AVMetadataFaceObject

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -97,7 +97,7 @@ CGFloat const kFocalPointOfInterestY = 0.5;
     NSParameterAssert(previewView);
     self = [super init];
     if (self) {
-        NSAssert(!([metaDataObjectTypes indexOfObject:AVMetadataObjectTypeFace] == NSNotFound),
+        NSAssert(!([metaDataObjectTypes indexOfObject:AVMetadataObjectTypeFace] != NSNotFound),
                  @"The type %@ is not supported by MTBBarcodeScanner.", AVMetadataObjectTypeFace);
         
         _metaDataObjectTypes = metaDataObjectTypes;


### PR DESCRIPTION
When you manually specify the type of AVMetadataObject in initWithMetadataObjectTypes method (e.g.
AVMetadataObjectTypeEAN13Code) the class goes in assertion because the
check, for my understanding, isn't correct. I fixed it.
