### PR TITLE
stopScanning AVCaptureSession cleanup bug fixes

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -149,7 +149,9 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 }
 
 - (void)stopScanning {
-	if ([MTBBarcodeScanner scanningIsAvailable] && self.capturePreviewLayer.superlayer) {
+	if ([MTBBarcodeScanner scanningIsAvailable] && self.hasExistingSession) {
+		
+		self.hasExistingSession = NO;
 		[self.capturePreviewLayer removeFromSuperlayer];
 		
 		dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{


### PR DESCRIPTION
Previously stopScanning did not correctly discard the existing session. This often resulted in the main thread infinitely locking on -[AVCaptureMetadataOutputInternal dealloc]. Using my iPhone 5 I was able to reproduce this every time in the given sample project when stopScanning was called in viewWillDisappear or viewDidDisappear. 

I've modified stopScanning to perform the cleanup necessary to resolve the issue.
[AVCaptureSession removeOutput] and [AVCaptureSession removeInput] often take a significant amount of time so these calls dispatched to a background thread.

I've also slightly modified the code to create new AVCaptureSessions and AVCaptureDevices. These are no longer directly attached to self.session and self.capture device.

https://gist.github.com/brandonschlenker/091d8a22ff5598244f5b
