### PR TITLE
Fixed app crash bug on basic example view controller.

### DIFF
--- a/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBBasicExampleViewController.m
+++ b/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBBasicExampleViewController.m
@@ -19,6 +19,13 @@
 
 @implementation MTBBasicExampleViewController
 
+#pragma mark - Properties
+
+- (void)setUniqueCodes:(NSMutableArray *)uniqueCodes {
+    _uniqueCodes = uniqueCodes;
+    [self.tableView reloadData];
+}
+
 #pragma mark - Lifecycle
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
In the basic example, after scanning a code, stopping the scan and then restarting the scan, touching the scan codes table in the view caused the device to crash because the array was empty but the table view hadn’t been refreshed. Added table reloading whenever setting the uniqueCodes array property.
