### PR TITLE
Added methods to test whether user has prohibited access to the camera

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -38,11 +38,32 @@
                                 previewView:(UIView *)previewView;
 
 /**
+ *  Returns whether the camera exists in this device.
+ *
+ *  @return YES if the device has a camera.
+ */
++ (BOOL)cameraIsPresent;
+
+/**
  *  Returns whether barcode scanning is supported on this device.
  *
  *  @return YES if barcode scanning is supported on this device.
  */
 + (BOOL)scanningIsAvailable;
+
+/**
+ *  Returns whether barcode scanning is supported on this device and allowed by the user.
+ *
+ *  @return YES if barcode scanning is supported and allowed.
+ */
++ (BOOL)scanningIsAvailableAndAllowed;
+
+/**
+ *  Returns whether scanning is prohibited by the user of the device.
+ *
+ *  @return YES if the user has prohibited access to (or is himself prohibited from accessing) the camera.
+ */
++ (BOOL)scanningIsProhibited;
 
 /**
  *  Start scanning for barcodes. The camera input will be added as a sublayer

--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -129,8 +129,35 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 
 #pragma mark - Scanning
 
++ (BOOL)cameraIsPresent {
+    return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+}
+
 + (BOOL)scanningIsAvailable {
     return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+}
+
++ (BOOL)scanningIsAvailableAndAllowed {
+    
+    if (![self cameraIsPresent] || [self scanningIsProhibited]) {
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
++ (BOOL)scanningIsProhibited {
+    
+    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+        case AVAuthorizationStatusDenied:
+        case AVAuthorizationStatusRestricted:
+            return YES;
+            break;
+            
+        default:
+            return NO;
+            break;
+    }
 }
 
 - (void)startScanningWithResultBlock:(void (^)(NSArray *codes))resultBlock {


### PR DESCRIPTION
'scanningIsAvailable' returns 'YES' if the camera exists, even if the user has prohibited access to the device.  I tripped over this in my app and decided it'd be nice to know we can't access the camera, even though it exists.  Rather than change 'scanningIsAvailable' and possibly break all current users of that method, I added 'scanningIsAvailableAndAuthorized'.  I also added 'scanningIsProhibited', using it in the other method, and so callers of 'scanningIsAvailableAndAuthorized' can obtain additional information.  While I was at it, I added 'cameraIsPresent'.  Though it is _exactly_ the same as 'scanningIsAvailable', it feels more intuitive to me.

Thanks for this excellent Cocoapod.
