### PR TITLE
Removed team ID

### DIFF
--- a/Project/MTBBarcodeScannerExample.xcodeproj/project.pbxproj
+++ b/Project/MTBBarcodeScannerExample.xcodeproj/project.pbxproj
@@ -288,7 +288,6 @@
 				LastUpgradeCheck = 0600;
 				TargetAttributes = {
 					27C3BF3D18A7140F00C44713 = {
-						DevelopmentTeam = K83F2KZFM9;
 					};
 					27C3BF6118A7140F00C44713 = {
 						TestTargetID = 27C3BF3D18A7140F00C44713;


### PR DESCRIPTION
Removed team ID from the example project settings to make it easier to fork the repo and run it on a device.