### PR TITLE
Reset focus

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -80,6 +80,11 @@ CGFloat const kFocalPointOfInterestX = 0.5;
 CGFloat const kFocalPointOfInterestY = 0.5;
 
 @implementation MTBBarcodeScanner
+{
+    AVCaptureAutoFocusRangeRestriction previousAutoFocusRangeRestricion;
+    CGPoint previousFocusPointOfInterest;
+    AVCaptureDeviceInput *deviceInput;
+}
 
 #pragma mark - Lifecycle
 
@@ -195,9 +200,7 @@ CGFloat const kFocalPointOfInterestY = 0.5;
         
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             
-            for(AVCaptureInput *input in self.session.inputs) {
-                [self.session removeInput:input];
-            }
+            [self removeDeviceInput];
             
             for(AVCaptureOutput *output in self.session.outputs) {
                 [self.session removeOutput:output];
@@ -276,11 +279,11 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 
 - (AVCaptureSession *)newSessionWithCaptureDevice:(AVCaptureDevice *)captureDevice {
     AVCaptureSession *newSession = [[AVCaptureSession alloc] init];
-    AVCaptureDeviceInput *input = [self deviceInputForCaptureDevice:captureDevice];
-    
     // Set an optimized preset for barcode scanning
     [newSession setSessionPreset:AVCaptureSessionPresetHigh];
-    [newSession addInput:input];
+    
+    AVCaptureDeviceInput *input = [self deviceInputForCaptureDevice:captureDevice];
+    [self setDeviceInput:input session:newSession];
     
     AVCaptureMetadataOutput *captureOutput = [[AVCaptureMetadataOutput alloc] init];
     [captureOutput setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
@@ -311,7 +314,6 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 - (AVCaptureDevice *)newCaptureDeviceWithCamera:(MTBCamera)camera {
     
     AVCaptureDevice *newCaptureDevice = nil;
-    NSError *lockError = nil;
     
     NSArray *videoDevices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
     AVCaptureDevicePosition position = [self devicePositionForCamera:camera];
@@ -327,23 +329,6 @@ CGFloat const kFocalPointOfInterestY = 0.5;
         newCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
     }
 
-    if ([newCaptureDevice lockForConfiguration:&lockError] == YES) {
-        
-        // Prioritize the focus on objects near to the device
-        if ([newCaptureDevice respondsToSelector:@selector(isAutoFocusRangeRestrictionSupported)] &&
-            newCaptureDevice.isAutoFocusRangeRestrictionSupported) {
-            newCaptureDevice.autoFocusRangeRestriction = AVCaptureAutoFocusRangeRestrictionNear;
-        }
-        
-        // Focus on the center of the image
-        if ([newCaptureDevice respondsToSelector:@selector(isFocusPointOfInterestSupported)] &&
-            newCaptureDevice.isFocusPointOfInterestSupported) {
-            newCaptureDevice.focusPointOfInterest = CGPointMake(kFocalPointOfInterestX, kFocalPointOfInterestY);
-        }
-        
-        [newCaptureDevice unlockForConfiguration];
-    }
-    
     return newCaptureDevice;
 }
 
@@ -398,18 +383,60 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 - (void)setCamera:(MTBCamera)camera {
     
     if (self.isScanning && camera != _camera) {
-        
-        for (AVCaptureInput *input in self.session.inputs) {
-            [self.session removeInput:input];
-        }
-        
         AVCaptureDevice *captureDevice = [self newCaptureDeviceWithCamera:camera];
         AVCaptureDeviceInput *input = [self deviceInputForCaptureDevice:captureDevice];
-        [self.session addInput:input];
-        
+        [self setDeviceInput:input session:self.session];
     }
     
     _camera = camera;
+}
+
+- (void)setDeviceInput:(AVCaptureDeviceInput *)input session:(AVCaptureSession *)session
+{
+    [self removeDeviceInput];
+    deviceInput = input;
+    
+    if ([deviceInput.device lockForConfiguration:nil] == YES) {
+        
+        // Prioritize the focus on objects near to the device
+        if ([deviceInput.device respondsToSelector:@selector(isAutoFocusRangeRestrictionSupported)] &&
+            deviceInput.device.isAutoFocusRangeRestrictionSupported) {
+            previousAutoFocusRangeRestricion = deviceInput.device.autoFocusRangeRestriction;
+            deviceInput.device.autoFocusRangeRestriction = AVCaptureAutoFocusRangeRestrictionNear;
+        }
+        
+        // Focus on the center of the image
+        if ([deviceInput.device respondsToSelector:@selector(isFocusPointOfInterestSupported)] &&
+            deviceInput.device.isFocusPointOfInterestSupported) {
+            previousFocusPointOfInterest = deviceInput.device.focusPointOfInterest;
+            deviceInput.device.focusPointOfInterest = CGPointMake(kFocalPointOfInterestX, kFocalPointOfInterestY);
+        }
+        
+        [deviceInput.device unlockForConfiguration];
+    }
+    
+    [session addInput:input];
+}
+
+- (void)removeDeviceInput
+{
+    // restore focus settings to the previously saved state
+    if ([deviceInput.device lockForConfiguration:nil] == YES) {
+        if ([deviceInput.device respondsToSelector:@selector(isAutoFocusRangeRestrictionSupported)] &&
+            deviceInput.device.isAutoFocusRangeRestrictionSupported) {
+            deviceInput.device.autoFocusRangeRestriction = previousAutoFocusRangeRestricion;
+        }
+        
+        if ([deviceInput.device respondsToSelector:@selector(isFocusPointOfInterestSupported)] &&
+            deviceInput.device.isFocusPointOfInterestSupported) {
+            deviceInput.device.focusPointOfInterest = previousFocusPointOfInterest;
+        }
+        
+        [deviceInput.device unlockForConfiguration];
+    }
+    
+    [self.session removeInput:deviceInput];
+    deviceInput = nil;
 }
 
 @end

--- a/MTBBarcodeScanner.podspec
+++ b/MTBBarcodeScanner.podspec
@@ -1,10 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MTBBarcodeScanner"
-<<<<<<< HEAD
-  s.version          = "1.3.2"
-=======
   s.version          = "1.4.0"
->>>>>>> release/1.4.0
   s.summary          = "A lightweight, easy-to-use barcode scanning library for iOS 7+."
   s.homepage         = "https://github.com/mikebuss/MTBBarcodeScanner"
   s.license          = 'MIT'


### PR DESCRIPTION
Hey, I'm a bit in a hurry and this PR is all I can do for now.

I refactored the class a little bit to save the current state of the camera and restore it once it's not needed anymore. This should also cover the case when flipping the camera while scanning (and `stopScanning` will be called with a different camera active than the initial camera).

I'm not too happy with the implementation but it was the best I could come up with right now. It still feels too complicated - like too many methods are calling each other in an unintuitive way or they are doing too much. Dunno, just a feeling.

I also added a button to the basic example view to crash the app on purpose. Looks fine - like the settings only persist while the app is running..? Also I wasn't able to get the near focus work for the current session (but didn't try too long).

Also no time to dig deeper and file a radar. I hope this is something you can work with.