### PR TITLE
Fixed torch to turn it on when start scanning if torch mode is MTBTorchModeOn

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -474,17 +474,13 @@ CGFloat const kFocalPointOfInterestY = 0.5;
 }
 
 - (void)updateTorchModeForCurrentSettings {
-    if (self.hasExistingSession && [self.currentCaptureDeviceInput.device hasTorch]) {
-        [self.session beginConfiguration];
-        
+    if ([self.currentCaptureDeviceInput.device hasTorch]) {
         if ([self.currentCaptureDeviceInput.device lockForConfiguration:nil] == YES) {
             
             AVCaptureTorchMode mode = [self avTorchModeForMTBTorchMode:self.torchMode];
             [self.currentCaptureDeviceInput.device setTorchMode:mode];
             [self.currentCaptureDeviceInput.device unlockForConfiguration];
         }
-        
-        [self.session commitConfiguration];
     }
 }
 


### PR DESCRIPTION
I noticed this issue when I tried to start scanning with torch mode set to `MTBTorchModeOn`.
If I tried to do that it wouldn't work because `hasExistingSession` property was still `NO`.

You can reproduce this issue using the following code:

```
_scanner = [[MTBBarcodeScanner alloc] initWithPreviewView:_previewView];
_scanner.torchMode = MTBTorchModeOn;
[_scanner startScanningWithResultBlock:^(NSArray *codes) {
}];
```