### PR TITLE
Added freeze and unfreeze capture methods

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -115,4 +115,15 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
  */
 - (void)toggleTorch;
 
+/**
+ *  Freeze capture keeping the last frame on previewView.
+ *  If this method is called before startScanning, it has no effect.
+ */
+- (void)freezeCapture;
+
+/**
+ *  Unfreeze a frozen capture
+ */
+- (void)unfreezeCapture;
+
 @end

--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -496,6 +496,27 @@ CGFloat const kFocalPointOfInterestY = 0.5;
     return mode;
 }
 
+#pragma mark - Capture
+
+- (void)freezeCapture
+{
+    self.capturePreviewLayer.connection.enabled = NO;
+    
+    if (self.hasExistingSession) {
+        [self.session stopRunning];
+    }
+}
+
+- (void)unfreezeCapture
+{
+    self.capturePreviewLayer.connection.enabled = YES;
+    
+    if (self.hasExistingSession && !self.session.isRunning) {
+        [self setDeviceInput:self.currentCaptureDeviceInput session:self.session];
+        [self.session startRunning];
+    }
+}
+
 #pragma mark - Setters
 
 - (void)setCamera:(MTBCamera)camera {


### PR DESCRIPTION
I have implemented 2 new methods to "freeze" and to "unfreeze" the capture without losing the image on previewView. I think this is useful for example to create a smooth transition after a capture.
I'm still not sure about the name though but it was the best I could thought to not get confused by start and stop scanning.

New methods:
`freezeCapture`
`unfreezeCapture`

Example:
```
[self.scanner startScanningWithResultBlock:^(NSArray *codes) {
       if (codes.count > 0) {
            [self.scanner freezeCapture];
            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                // do something; for example: open a new view controller                
                [self.scanner unfreezeCapture];
            });
        }
    }];
```