### PR TITLE
Fixes #71: Crash when result block is nil

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -355,6 +355,8 @@ static const NSInteger kErrorCodeSessionIsClosed = 1001;
 
 - (void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection {
     
+    if (!self.resultBlock) return;
+    
     NSMutableArray *codes = [[NSMutableArray alloc] init];
     
     for (AVMetadataObject *metaData in metadataObjects) {


### PR DESCRIPTION
As detailed in https://github.com/mikebuss/MTBBarcodeScanner/issues/71, the result block may sometimes be invoked when scanning has stopped, which will cause a crash. 