### PR TITLE
iOS 10 NSCameraUsageDescription Fix

### DIFF
--- a/Project/MTBBarcodeScanner/Info.plist
+++ b/Project/MTBBarcodeScanner/Info.plist
@@ -22,5 +22,7 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
+	<key>NSCameraUsageDescription</key>
+	<string>For testing purposes</string>
 </dict>
 </plist>


### PR DESCRIPTION
When testing the example project with iOS 10, you need to include NSCameraUsageDescription in the info plist otherwise the app will crash.