### PR TITLE
iOS 10 NSCameraUsageDescription Fix

### DIFF
--- a/Project/MTBBarcodeScannerExample/MTBBarcodeScannerExample-Info.plist
+++ b/Project/MTBBarcodeScannerExample/MTBBarcodeScannerExample-Info.plist
@@ -47,5 +47,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>For testing purposes</string>
 </dict>
 </plist>


### PR DESCRIPTION
When testing the example project with iOS 10, you need to include NSCameraUsageDescription in the info plist otherwise the app will crash.