### PR TITLE
Propagate errors from AVFoundation into the `startScanning` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MTBBarcodeScanner CHANGELOG
 
+## [Unreleased]
+
+- Errors are now propagated to the `startScanning` methods. You may now supply an NSError to this method that will be updated in the event scanning could not be started.
+
 ## 2.1.0
 
 - Now uses AVCaptureFocusModeContinuousAutoFocus by default, per issue [#81](https://github.com/mikebuss/MTBBarcodeScanner/issues/81). Thanks [@JacopoKenzo](https://github.com/JacopoKenzo)!

--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -135,16 +135,19 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
  *  to the UIView given for previewView during initialization.
  *
  *  This method assumes you have already set the `resultBlock` property directly.
+ *
+ *  @param error Error supplied if the scanning could not start.
  */
-- (void)startScanning;
+- (void)startScanningWithError:(NSError **)error;
 
 /**
  *  Start scanning for barcodes. The camera input will be added as a sublayer
  *  to the UIView given for previewView during initialization.
  *
  *  @param resultBlock Callback block for captured codes. If the scanner was instantiated with initWithMetadataObjectTypes:previewView, only codes with a type given in metaDataObjectTypes will be reported.
+ *  @param error Error supplied if the scanning could not start.
  */
-- (void)startScanningWithResultBlock:(void (^)(NSArray *codes))resultBlock;
+- (void)startScanningWithResultBlock:(void (^)(NSArray *codes))resultBlock error:(NSError **)error;
 
 /**
  *  Stop scanning for barcodes. The live feed from the camera will be removed as a sublayer from the previewView given during initialization.

--- a/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBAdvancedExampleViewController.m
+++ b/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBAdvancedExampleViewController.m
@@ -85,9 +85,14 @@
               Here we could present a view at %@", NSStringFromCGPoint(point));
     };
     
+    NSError *error;
     [self.scanner startScanningWithResultBlock:^(NSArray *codes) {
         [self drawOverlaysOnCodes:codes];
-    }];
+    } error:&error];
+    
+    if (error) {
+        NSLog(@"An error occurred: %@", error.localizedDescription);
+    }
     
     // Optionally set a rectangle of interest to scan codes. Only codes within this rect will be scanned.
     self.scanner.scanRect = self.viewOfInterest.frame;

--- a/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBBasicExampleViewController.m
+++ b/Project/MTBBarcodeScannerExample/Classes/Controllers/MTBBasicExampleViewController.m
@@ -54,6 +54,7 @@
 - (void)startScanning {
     self.uniqueCodes = [[NSMutableArray alloc] init];
     
+    NSError *error = nil;
     [self.scanner startScanningWithResultBlock:^(NSArray *codes) {
         for (AVMetadataMachineReadableCodeObject *code in codes) {
             if (code.stringValue && [self.uniqueCodes indexOfObject:code.stringValue] == NSNotFound) {
@@ -66,7 +67,11 @@
                 [self scrollToLastTableViewCell];
             }
         }
-    }];
+    } error:&error];
+    
+    if (error) {
+        NSLog(@"An error occurred: %@", error.localizedDescription);
+    }
     
     [self.toggleScanningButton setTitle:@"Stop Scanning" forState:UIControlStateNormal];
     self.toggleScanningButton.backgroundColor = [UIColor redColor];

--- a/README.md
+++ b/README.md
@@ -96,12 +96,13 @@ To read the first code and stop scanning:
 [MTBBarcodeScanner requestCameraPermissionWithSuccess:^(BOOL success) {
     if (success) {
 
+        NSError *error = nil;
         [self.scanner startScanningWithResultBlock:^(NSArray *codes) {
             AVMetadataMachineReadableCodeObject *code = [codes firstObject];
             NSLog(@"Found code: %@", code.stringValue);
 
             [self.scanner stopScanning];
-        }];
+        } error:&error];
 
     } else {
         // The user denied access to the camera
@@ -112,12 +113,13 @@ To read the first code and stop scanning:
 If the camera is pointed at more than one 2-dimensional code, you can read all of them:
 
 ```objective-c
+NSError *error = nil;
 [self.scanner startScanningWithResultBlock:^(NSArray *codes) {
     for (AVMetadataMachineReadableCodeObject *code in codes) {
         NSLog(@"Found code: %@", code.stringValue);
     }
     [self.scanner stopScanning];
-}];
+} error:&error];
 ```
 
 **Note:** This only applies to 2-dimensional barcodes as 1-dimensional barcodes can only be read one at a time. See [relevant Apple document](https://developer.apple.com/library/ios/technotes/tn2325/_index.html).
@@ -125,6 +127,7 @@ If the camera is pointed at more than one 2-dimensional code, you can read all o
 To continuously read and only output unique codes:
 
 ```objective-c
+NSError *error = nil;
 [self.scanner startScanningWithResultBlock:^(NSArray *codes) {
     for (AVMetadataMachineReadableCodeObject *code in codes) {
         if ([self.uniqueCodes indexOfObject:code.stringValue] == NSNotFound) {
@@ -132,7 +135,7 @@ To continuously read and only output unique codes:
             NSLog(@"Found unique code: %@", code.stringValue);
         }
     }
-}];
+} error:&error];
 ```
 
 #### Callback Blocks


### PR DESCRIPTION
This will be released in v3.0.0 and will require updating the methods you use to scan from:

```objective-c
- (void)startScanning;
- (void)startScanningWithResultBlock:(void (^)(NSArray *codes))resultBlock;
```

to:

```objective-c
- (void)startScanningWithError:(NSError **)error;
- (void)startScanningWithResultBlock:(void (^)(NSArray *codes))resultBlock error:(NSError **)error;
```

Basic usage will be:

```objective-c
NSError *error = nil;
[self.scanner startScanningWithResultBlock:^(NSArray *codes) {
    for (AVMetadataMachineReadableCodeObject *code in codes) {
        NSLog(@"Found code: %@", code.stringValue);
    }
    [self.scanner stopScanning];
} error:&error];

if (error) {
   // Handle error
}
```