### PR TITLE
Add documentation and assert/safeguard when attempting to set the scan rect too early

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -49,6 +49,10 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
 
 /**
  *  If set, only barcodes inside this area will be scanned.
+ *
+ *  Setting this property is only supported while the scanner is active.
+ *  Use the didStartScanningBlock if you want to set it as early as
+ *  possible.
  */
 @property (nonatomic, assign) CGRect scanRect;
 

--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -848,6 +848,11 @@ static const NSInteger kErrorCodeTorchModeUnavailable = 1004;
 
 - (void)setScanRect:(CGRect)scanRect {
     NSAssert(!CGRectIsEmpty(scanRect), @"Unable to set an empty rectangle as the scanRect of MTBBarcodeScanner");
+    NSAssert(self.isScanning, @"Scan rect cannot be set when not (yet) scanning. You may want to set it within didStartScanningBlock.");
+
+    if (!self.isScanning) {
+        return;
+    }
     
     [self refreshVideoOrientation];
     


### PR DESCRIPTION
Addresses issue discussed in https://github.com/mikebuss/MTBBarcodeScanner/pull/108