### PR TITLE
Add comments regarding AVAuthorizationStatusRestricted

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -140,8 +140,9 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
 
 /**
  *  Returns whether any camera exists in this device.
+ *  Be aware that this returns NO if camera access is restricted.
  *
- *  @return YES if the device has a camera.
+ *  @return YES if the device has a camera and authorization state is not AVAuthorizationStatusRestricted
  */
 + (BOOL)cameraIsPresent;
 
@@ -150,7 +151,7 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
  *  be successful. You may want to hide your button to flip the camera
  *  if the device only has one camera.
  *
- *  @return YES if a second camera is present.
+ *  @return YES if a second camera is present and authorization state is not AVAuthorizationStatusRestricted.
  *  @sa flipCamera
  */
 - (BOOL)hasOppositeCamera;

--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -174,12 +174,14 @@ static const NSInteger kErrorCodeTorchModeUnavailable = 1004;
 #pragma mark - Scanning
 
 + (BOOL)cameraIsPresent {
+    // capture device is nil if status is AVAuthorizationStatusRestricted
     return [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo] != nil;
 }
 
 + (BOOL)hasCamera:(MTBCamera)camera {
     AVCaptureDevicePosition position = [self devicePositionForCamera:camera];
 
+    // array is empty if status is AVAuthorizationStatusRestricted
     for (AVCaptureDevice *device in [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo]) {
         if (device.position == position) {
             return YES;


### PR DESCRIPTION
Ran into `cameraIsPresent` returning `NO` when state is AVAuthorizationStatusRestricted.
Tried to "fix" it in https://github.com/sumup/MTBBarcodeScanner/pull/6  but it turned out that this was deliberately changed to resolve https://github.com/mikebuss/MTBBarcodeScanner/issues/86. So I settled for some comments regarding the limitation of the check. 