### PR TITLE
Blocks should have void as argument if it accepts no arguments

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.h
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.h
@@ -80,7 +80,7 @@ typedef NS_ENUM(NSUInteger, MTBTorchMode) {
  
  The block is always called on the main queue.
  */
-@property (nonatomic, copy) void (^didStartScanningBlock)();
+@property (nonatomic, copy) void (^didStartScanningBlock)(void);
 
 /*!
  @property didTapToFocusBlock


### PR DESCRIPTION
Declaring no arguments leads to block accepting any number of arguments
New warning introduced in Xcode 9