### PR TITLE
Fix rare crash when stopping the barcode scanner

### DIFF
--- a/Classes/ios/Scanners/MTBBarcodeScanner.m
+++ b/Classes/ios/Scanners/MTBBarcodeScanner.m
@@ -356,6 +356,7 @@ static const NSInteger kErrorMethodNotAvailableOnIOSVersion = 1005;
     [self stopRecognizingTaps];
     
     self.resultBlock = nil;
+    self.capturePreviewLayer.session = nil;
     self.capturePreviewLayer = nil;
     
     AVCaptureSession *session = self.session;


### PR DESCRIPTION
This fixes an issue tracked here https://github.com/mikebuss/MTBBarcodeScanner/issues/146.

Initially, we tried what [@AlexanderPan](https://github.com/AlexanderPan) suggested and dispatched the call to stop the scanner. It seemed to resolve the issue for the most part but we still experienced a few of the same crashes.

In an attempt to resolve it, we looked for alternative solutions and found [this](https://stackoverflow.com/questions/29569208/rare-crash-during-dealloc-avcapturevideopreviewlayer) post suggesting that we nullify the session in the preview layer before nullifying the scanner's session. We are not sure if this actually fixes the problem but surely it does not hurt the functionality of the scanner. At the very least, it fixes issue 146 (linked above) without having to resort to the dispatching the `stopScanning` call.